### PR TITLE
Remove event type requirement for pr publishing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19732,71 +19732,6 @@ module.exports = function (data, options) {
 
 /***/ }),
 
-/***/ 7968:
-/***/ ((module) => {
-
-"use strict";
-
-
-module.exports = {
-    /**
-     * True if this is running in Nodejs, will be undefined in a browser.
-     * In a browser, browserify won't include this file and the whole module
-     * will be resolved an empty object.
-     */
-    isNode : typeof Buffer !== "undefined",
-    /**
-     * Create a new nodejs Buffer from an existing content.
-     * @param {Object} data the data to pass to the constructor.
-     * @param {String} encoding the encoding to use.
-     * @return {Buffer} a new Buffer.
-     */
-    newBufferFrom: function(data, encoding) {
-        if (Buffer.from && Buffer.from !== Uint8Array.from) {
-            return Buffer.from(data, encoding);
-        } else {
-            if (typeof data === "number") {
-                // Safeguard for old Node.js versions. On newer versions,
-                // Buffer.from(number) / Buffer(number, encoding) already throw.
-                throw new Error("The \"data\" argument must not be a number");
-            }
-            return new Buffer(data, encoding);
-        }
-    },
-    /**
-     * Create a new nodejs Buffer with the specified size.
-     * @param {Integer} size the size of the buffer.
-     * @return {Buffer} a new Buffer.
-     */
-    allocBuffer: function (size) {
-        if (Buffer.alloc) {
-            return Buffer.alloc(size);
-        } else {
-            var buf = new Buffer(size);
-            buf.fill(0);
-            return buf;
-        }
-    },
-    /**
-     * Find out if an object is a Buffer.
-     * @param {Object} b the object to test.
-     * @return {Boolean} true if the object is a Buffer, false otherwise.
-     */
-    isBuffer : function(b){
-        return Buffer.isBuffer(b);
-    },
-
-    isStream : function (obj) {
-        return obj &&
-            typeof obj.on === "function" &&
-            typeof obj.pause === "function" &&
-            typeof obj.resume === "function";
-    }
-};
-
-
-/***/ }),
-
 /***/ 3581:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -19925,6 +19860,71 @@ NodejsStreamOutputAdapter.prototype._read = function() {
 };
 
 module.exports = NodejsStreamOutputAdapter;
+
+
+/***/ }),
+
+/***/ 7968:
+/***/ ((module) => {
+
+"use strict";
+
+
+module.exports = {
+    /**
+     * True if this is running in Nodejs, will be undefined in a browser.
+     * In a browser, browserify won't include this file and the whole module
+     * will be resolved an empty object.
+     */
+    isNode : typeof Buffer !== "undefined",
+    /**
+     * Create a new nodejs Buffer from an existing content.
+     * @param {Object} data the data to pass to the constructor.
+     * @param {String} encoding the encoding to use.
+     * @return {Buffer} a new Buffer.
+     */
+    newBufferFrom: function(data, encoding) {
+        if (Buffer.from && Buffer.from !== Uint8Array.from) {
+            return Buffer.from(data, encoding);
+        } else {
+            if (typeof data === "number") {
+                // Safeguard for old Node.js versions. On newer versions,
+                // Buffer.from(number) / Buffer(number, encoding) already throw.
+                throw new Error("The \"data\" argument must not be a number");
+            }
+            return new Buffer(data, encoding);
+        }
+    },
+    /**
+     * Create a new nodejs Buffer with the specified size.
+     * @param {Integer} size the size of the buffer.
+     * @return {Buffer} a new Buffer.
+     */
+    allocBuffer: function (size) {
+        if (Buffer.alloc) {
+            return Buffer.alloc(size);
+        } else {
+            var buf = new Buffer(size);
+            buf.fill(0);
+            return buf;
+        }
+    },
+    /**
+     * Find out if an object is a Buffer.
+     * @param {Object} b the object to test.
+     * @return {Boolean} true if the object is a Buffer, false otherwise.
+     */
+    isBuffer : function(b){
+        return Buffer.isBuffer(b);
+    },
+
+    isStream : function (obj) {
+        return obj &&
+            typeof obj.on === "function" &&
+            typeof obj.pause === "function" &&
+            typeof obj.resume === "function";
+    }
+};
 
 
 /***/ }),
@@ -56551,10 +56551,6 @@ async function runFromWorkflow() {
     // Step 1
     if (workflow_run.conclusion != 'success') {
         console.log('Aborting, workflow run was not successful');
-        return;
-    }
-    if (workflow_run.event != 'pull_request') {
-        console.log(`Aborting, only events of type 'pull_request' can trigger publishing`);
         return;
     }
     if (!workflow_run.head_branch) {

--- a/src/pr_publish.ts
+++ b/src/pr_publish.ts
@@ -29,13 +29,6 @@ export async function runFromWorkflow(): Promise<void> {
     return
   }
 
-  if (workflow_run.event != 'pull_request') {
-    console.log(
-      `Aborting, only events of type 'pull_request' can trigger publishing`
-    )
-    return
-  }
-
   if (!workflow_run.head_branch) {
     console.log(`Unknown head branch...`)
     return


### PR DESCRIPTION
The existing PR discovery logic can handle other events fine (for example `push` to a branch with a PR open)